### PR TITLE
docs: Update RTD Config.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,15 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
+# Set the version of python needed to build these docs.
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+  apt_packages:
+    - graphviz
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
   install:
   - requirements: requirements/docs.txt


### PR DESCRIPTION
RTD deprectade defining the python version in the python top-level
setting.  It now has to be part of the build OS which is a required
setting.

I also added graphviz here in-case we want to add diagrams in the aspect
docs.
