### PR TITLE
build: Manually pull some RTD Context.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -106,5 +106,15 @@ html_theme_options = {
 html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 html_favicon = "https://logos.openedx.org/openedx-favicon.ico"
 
+
+# -- Read the Docs Specific Configuration
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # -- Extension configuration -------------------------------------------------


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/07/addons-by-default/ for details but
essentially RTD is changing how it's building docs and this will let us handle the
change gracefully.
