### PR TITLE
fix: wrong variable name to enable PII

### DIFF
--- a/docs/technical_documentation/how-tos/production_configuration.rst
+++ b/docs/technical_documentation/how-tos/production_configuration.rst
@@ -168,6 +168,11 @@ By default Aspects does not store information that can directly link the xAPI le
 
 Setting ``ASPECTS_ENABLE_PII`` to ``True``, then running Tutor init for the Aspects plugin, turns on the ability to send user data to ClickHouse. When turned on this populates the ``event_sink.external_id`` and ``event_sink.user_profile`` tables as new users are created.
 
+.. code-block:: bash
+
+    tutor config save -s ASPECTS_ENABLE_PII=true
+    tutor dev|local|k8s do init -l aspects
+
 However it does not copy over existing users, see :ref:`Backfilling Existing Data` below for more information on how to do that.
 
 XAPI User Id Type

--- a/docs/technical_documentation/how-tos/production_configuration.rst
+++ b/docs/technical_documentation/how-tos/production_configuration.rst
@@ -166,7 +166,7 @@ Personally Identifiable Identification
 
 By default Aspects does not store information that can directly link the xAPI learning traces to an individual's name, email address, username, etc. Storing this information has potential legal consequences and should be undertaken with careful consideration.
 
-Setting ``ASPECTS_ENABLE_USER_PII`` to ``True``, then running Tutor init for the Aspects plugin, turns on the ability to send user data to ClickHouse. When turned on this populates the ``event_sink.external_id`` and ``event_sink.user_profile`` tables as new users are created.
+Setting ``ASPECTS_ENABLE_PII`` to ``True``, then running Tutor init for the Aspects plugin, turns on the ability to send user data to ClickHouse. When turned on this populates the ``event_sink.external_id`` and ``event_sink.user_profile`` tables as new users are created.
 
 However it does not copy over existing users, see :ref:`Backfilling Existing Data` below for more information on how to do that.
 
@@ -256,7 +256,7 @@ There is a management command to populate course data for one, all, or a subset 
     tutor local run lms ./manage.py lms dump_data_to_clickhouse --object course_overviews
 
 
-If you are running with ``ASPECTS_ENABLE_USER_PII`` set to ``True`` you will need to populate the user PII data with these commands:
+If you are running with ``ASPECTS_ENABLE_PII`` set to ``True`` you will need to populate the user PII data with these commands:
 
 .. code-block::
 


### PR DESCRIPTION
Enabling PII sharing for users inside `docs/technical_documentation/how-tos/production_configuration.rst` mentioned `ASPECTS_ENABLE_USER_PII`

https://docs.openedx.org/projects/openedx-aspects/en/latest/technical_documentation/how-tos/production_configuration.html#personally-identifiable-identification

instead of `ASPECTS_ENABLE_PII` that used in the plugin:

https://github.com/openedx/tutor-contrib-aspects/blob/984e63495abeb020fbd31f07e14dc8d0833d1ef6/tutoraspects/plugin.py#L52

This will take care of that and will add a small command instruction to enable it using tutor.