### PR TITLE
chore: Adds openedx release annotation to the catalog-info file.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,6 +14,7 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "bmtcril,feanil"
+    openedx.org/release: "main"
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
## Description

This PR adds the key to catalog-info so that we can tag a release automatically next time.