### PR TITLE
docs: Update outdated link target URLs

### DIFF
--- a/docs/technical_documentation/decisions/0009_pii.rst
+++ b/docs/technical_documentation/decisions/0009_pii.rst
@@ -74,4 +74,4 @@ References
 **********
 
 - `OEP-30: PII Markup and Auditing <https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0030-arch-pii-markup-and-auditing.html/>`_
-- `Enabling the User Retirement Feature <https://docs.openedx.org/projects/edx-platform/en/latest/references/docs/scripts/user_retirement/docs/index.html/>`_
+- `Enabling the User Retirement Feature <https://docs.openedx.org/projects/edx-platform/en/latest/references/docs/scripts/user_retirement/docs/index.html>`_

--- a/docs/technical_documentation/decisions/0009_pii.rst
+++ b/docs/technical_documentation/decisions/0009_pii.rst
@@ -74,4 +74,4 @@ References
 **********
 
 - `OEP-30: PII Markup and Auditing <https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0030-arch-pii-markup-and-auditing.html/>`_
-- `Enabling the User Retirement Feature <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/index.html/>`_
+- `Enabling the User Retirement Feature <https://docs.openedx.org/projects/edx-platform/en/latest/references/docs/scripts/user_retirement/docs/index.html/>`_


### PR DESCRIPTION
This required some fair bit of sleuthing! These docs were actually moved to the edx-platform project in https://github.com/openedx/edx-documentation/pull/2257 so update to the new location.