### PR TITLE
build: Untag this repo for release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,6 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "bmtcril,feanil"
-    openedx.org/release: "main"
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
This repo was previously tagged for release only to facilitate docs builds. As it is a transitive dependency, it should not be tagged for release. Please see https://github.com/openedx/docs.openedx.org/issues/941 for more detail.
