### PR TITLE
docs: Add crossreference for docs linking

### DIFF
--- a/docs/reference/in_context_dashboards.rst
+++ b/docs/reference/in_context_dashboards.rst
@@ -1,3 +1,5 @@
+.. _In-Context Dashboards:
+
 In-Context Dashboards
 #####################
 


### PR DESCRIPTION
This will make docs cross referencing more flexible rather than having to hard-link to a document's name.