### PR TITLE
Revert "build: Untag this repo for release"

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,6 +14,7 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "bmtcril,feanil"
+    openedx.org/release: "main"
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
Reverts openedx/openedx-aspects#312

Per discussion with @saraburns1 we've decided that since this is a documentation repo (and _not_ a transitive dependency) that we actually ought to tag this for release 🙂 